### PR TITLE
Adding Tampa Bay WordPress

### DIFF
--- a/assets/orgs.rb
+++ b/assets/orgs.rb
@@ -34,6 +34,7 @@ estimates = [
   Code-Katas
   ReactJS-Tampa-Bay
   Saint-Petersburg-Python-Meetup
+  Tampa-Bay-WordPress
 ].each do |urlname|
   open("https://api.meetup.com/#{urlname}?key=#{ENV['MEETUP_API_KEY']}") do |io|
     group = JSON.parse(io.read)


### PR DESCRIPTION
Per our chat on Slack, adding Tampa-Bay-WordPress to the list of Suncoast Developers
https://www.meetup.com/Tampa-Bay-WordPress/
